### PR TITLE
Upgrade graphite to 0.9.15

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ namespace :build do
   end
 end
 
-desc "Push all images to our registry"
+desc "Push all images to registry"
 task :push do
   sh "docker push banno/carbon-base"
   sh "docker push banno/carbon-cache"

--- a/carbon-base/Dockerfile
+++ b/carbon-base/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-ENV GRAPHITE_VERSION 0.9.14
+ENV GRAPHITE_VERSION 0.9.15
 
 RUN apt-get update && \
     apt-get -y install python-dev python-pip


### PR DESCRIPTION
```
....

Finished in 10.34 seconds (files took 0.27305 seconds to load)
4 examples, 0 failures
```

Already pushing the images to the docker hub.

Closes Banno/infrastructure#97
