### PR TITLE
default to expecting data at 1 minute intervals and dont rollup

### DIFF
--- a/carbon-cache/config/storage-schemas.conf
+++ b/carbon-cache/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 10s:1d,1m:7d,10m:1y
+retentions = 1m:1y


### PR DESCRIPTION
Our default for metrics was set to expect data points at 10 second intervals, but most things we send at 1 minute intervals.  The result is broken graphs, and functions in graphite and wsp files that are filled with null values that occupy more space than is needed for the metric rate.

This sets the default expected metric interval to 1m with a rollup to 5m resolution at 1yr and will increase the size of each whisper file from 0.833Mb to 1.2Mb but with no null values.  No change in size will happen for existing metrics.  We'll need to rewrite them for that to happen.
