### PR TITLE
Storage schema

### DIFF
--- a/carbon-cache/config/storage-schemas.conf
+++ b/carbon-cache/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 10s:1d,1m:7d,10m:1y
+retentions = 1m:1y

--- a/carbon-cache/config/storage-schemas.conf
+++ b/carbon-cache/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 1m:1y,5m:1y
+retentions = 1m:1d,5m:1y

--- a/carbon-cache/config/storage-schemas.conf
+++ b/carbon-cache/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 1m:1y
+retentions = 1m:1y,5m:1y

--- a/carbon-relay/config/storage-schemas.conf
+++ b/carbon-relay/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 1m:1y,5m:1y
+retentions = 1m:1d,5m:1y

--- a/carbon-relay/config/storage-schemas.conf
+++ b/carbon-relay/config/storage-schemas.conf
@@ -12,4 +12,4 @@ retentions = 1m:7d,10m:1y
 
 [default]
 pattern = .*
-retentions = 10s:1d,1m:7d,10m:1y
+retentions = 1m:1y,5m:1y

--- a/test/spec/graphite_spec.rb
+++ b/test/spec/graphite_spec.rb
@@ -8,7 +8,10 @@ describe 'graphite' do
 
   it 'writes the data to whisper' do
     client = GraphiteAPI.new( graphite: 'relay:2003' )
-    client.metrics("test.serverspec" => 1)
+    for i in 1..2 do
+      client.metrics("test.serverspec" => 1)
+      sleep 30
+    end
     sleep 5
     expect(file('/opt/graphite/storage/whispera/test/serverspec.wsp')).to be_file
     expect(file('/opt/graphite/storage/whisperb/test/serverspec.wsp')).to_not be_file
@@ -26,7 +29,7 @@ describe 'graphite' do
     conn = Faraday.new(:url => "http://web") do |faraday|
       faraday.adapter Faraday.default_adapter
     end
-    datapoints = JSON.parse(conn.get('/render?&target=test.serverspec&from=-1min&rawData=true&format=json').body).first['datapoints'].map {|k| k.first}
+    datapoints = JSON.parse(conn.get('/render?&target=test.serverspec&from=-2min&rawData=true&format=json').body).first['datapoints'].map {|k| k.first}
     unique_datapoints = datapoints.to_set.size
     expect(unique_datapoints).to be > 1
   end


### PR DESCRIPTION
Our default for metrics was set to expect data points at 10 second intervals, but most things we send at 1 minute intervals. The result is broken graphs, and functions in graphite and wsp files that are filled with null values that occupy more space than is needed for the metric rate.

This sets the default expected metric interval to 1m with a rollup to 5m resolution at 1yr and will increase the size of each whisper file from 0.833Mb to 1.2Mb but with no null values. No change in size will happen for existing metrics. We'll need to rewrite them for that to happen.
