### PR TITLE
Add graphite cluster discovery support using rancher

### DIFF
--- a/web/config/local_settings.py
+++ b/web/config/local_settings.py
@@ -1,4 +1,5 @@
 import os
+import json, requests
 from datetime import datetime
 
 LOG_DIR = '/var/log/graphite'
@@ -7,6 +8,11 @@ if os.getenv("CARBONLINK_HOSTS"):
 
 if os.getenv("CLUSTER_SERVERS"):
     CLUSTER_SERVERS = os.getenv("CLUSTER_SERVERS").split(',')
+elif os.getenv("RANCHER_GRAPHITE_CLUSTER_SERVICE_NAME"):
+    rancher_carbonlink_service_url = "http://rancher-metadata/2015-12-19/services/%s/containers" % os.getenv("RANCHER_GRAPHITE_CLUSTER_SERVICE_NAME")
+    r = requests.get(rancher_carbonlink_service_url, headers={"Accept": "application/json"}).json()
+    r = map(lambda x: x["primary_ip"] + ":80", r)
+    CLUSTER_SERVERS = [str(x) for x in r]
 
 if os.getenv("MEMCACHE_HOSTS"):
     CLUSTER_SERVERS = os.getenv("MEMCACHE_HOSTS").split(',')


### PR DESCRIPTION
To use this feature, set `RANCHER_GRAPHITE_CLUSTER_SERVICE_NAME` environment variable to the graphite cluster service name you defined in Rancher, for example `graphite-web`.
