### PR TITLE
Fix memcache hosts setting from env

### DIFF
--- a/web/config/local_settings.py
+++ b/web/config/local_settings.py
@@ -9,7 +9,7 @@ if os.getenv("CLUSTER_SERVERS"):
     CLUSTER_SERVERS = os.getenv("CLUSTER_SERVERS").split(',')
 
 if os.getenv("MEMCACHE_HOSTS"):
-    CLUSTER_SERVERS = os.getenv("MEMCACHE_HOSTS").split(',')
+    MEMCACHE_HOSTS = os.getenv("MEMCACHE_HOSTS").split(',')
 
 if os.getenv("WHISPER_DIR"):
     WHISPER_DIR = os.getenv("WHISPER_DIR")


### PR DESCRIPTION
Before this fix if one had set OS env vars for both CLUSTER_SERVERS and
MEMCACHE_HOSTS the value of later would override the former and the
graphite web application fails to show any metrics.
